### PR TITLE
Support file header with variable length (#537)

### DIFF
--- a/src/ImageProcessor/Imaging/Formats/FormatUtilities.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatUtilities.cs
@@ -46,7 +46,9 @@ namespace ImageProcessor.Imaging.Formats
             IEnumerable<ISupportedImageFormat> supportedImageFormats =
                 ImageProcessorBootstrapper.Instance.SupportedImageFormats;
 
-            byte[] buffer = new byte[4];
+            var numberOfBytesToRead = supportedImageFormats.Max(f => f.FileHeaders.Max(h=>h.Length));
+
+            byte[] buffer = new byte[numberOfBytesToRead];
             stream.Read(buffer, 0, buffer.Length);
 
             foreach (ISupportedImageFormat supportedImageFormat in supportedImageFormats)


### PR DESCRIPTION
This will also allow to have [jpegs with longer fileheaders](https://github.com/JimBobSquarePants/ImageProcessor/blob/develop/src/ImageProcessor/Imaging/Formats/JpegFormat.cs#L31):
